### PR TITLE
Update types for setUserId to allow logging out

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -233,7 +233,7 @@ declare module 'react-native-iaphub' {
    * ⚠ You should provide an id that is non-guessable and isn't public. (Email not allowed)
    * @param UniqueUserId Non-guessable unique identifier of user.
    */
-  export function setUserId(UniqueUserId: string): Promise<void>;
+  export function setUserId(UniqueUserId: string | null): Promise<void>;
 
   /***
    * Call the ``getProductsForSale`` method to get the products for sale.

--- a/src/index.js
+++ b/src/index.js
@@ -93,7 +93,7 @@ class Iaphub {
 
   /*
    * Set user id (or device id)
-   * @param {String} userId User id
+   * @param {String|null} userId User id
    */
   async setUserId(userId) {
     if (!this.isInitialized) {


### PR DESCRIPTION
The README suggests setUserId(null) to log a user out, so this updates the `@param` type to match that suggestion.

Without this change, TypeScript users need to override the type for `null` when logging a user out, which is a bit awkward: 

```typescript
await Iaphub.setUserId(null as any);
```