### PR TITLE
Fixed path to typescript types

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "The easiest way to implement IAP (In-app purchase) in your React Native app",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",
-  "types": "lib/typescript/src/index.d.ts",
+  "types": "lib/typescript/index.d.ts",
   "react-native": "src/index",
   "source": "src/index",
   "files": [


### PR DESCRIPTION
This is consistent with the default options described: [https://github.com/callstack/react-native-builder-bob](https://github.com/callstack/react-native-builder-bob)

Fixes #125 

Was unsure of the procedure for submitting to this repo, but this did fix an issue I experienced.