### PR TITLE
Corrected type of billing status

### DIFF
--- a/src/models/billing-status.tsx
+++ b/src/models/billing-status.tsx
@@ -9,6 +9,6 @@ export default interface BillingStatus {
   /**
    * Filtered products ids
    */
-  readonly filteredProductIds: [string]
+  readonly filteredProductIds: string[]
 
 }


### PR DESCRIPTION
It is likely that the intended type is an array of strings, not a tuple containing one string.

This fixes #138 